### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## How do I make a good changelog?
+
+### Guiding Principles
+
+- Changelogs are for humans, not machines.
+- There should be an entry for every single version.
+- The same types of changes should be grouped.
+- Versions and sections should be linkable.
+- The latest version comes first.
+- The release date of each version is displayed.
+- Mention whether you follow Semantic Versioning.
+
+### Types of changes
+
+- Added for new features.
+- Changed for changes in existing functionality.
+- Deprecated for soon-to-be removed features.
+- Removed for now removed features.
+- Fixed for any bug fixes.
+- Security in case of vulnerabilities.
+
+## [Unreleased]
+
+- nil
+
+---
+
+[0.2.0] - 2023-12-11
+
+- Add .ruby-version, Gemfile.lock, and GH test suite [#3](https://github.com/Shopify/annex-29/pull/3)
+- Set "Shopify developers" as gem owners; move to MIT license [#5](https://github.com/Shopify/annex-29/pull/5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    annex_29 (0.1.1)
+    annex_29 (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/annex_29/version.rb
+++ b/lib/annex_29/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Annex29
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
- Add .ruby-version, Gemfile.lock, and GH test suite [#3](https://github.com/Shopify/annex-29/pull/3)
- Set "Shopify developers" as gem owners; move to MIT license [#5](https://github.com/Shopify/annex-29/pull/5)