### PR TITLE
Update CHANGELOG to include rake bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add .ruby-version, Gemfile.lock, and GH test suite [#3](https://github.com/Shopify/annex-29/pull/3)
 - Set "Shopify developers" as gem owners; move to MIT license [#5](https://github.com/Shopify/annex-29/pull/5)
+- Bump rake gem from 11.3.0 to 13.1.0 [#6](https://github.com/Shopify/annex-29/pull/6)


### PR DESCRIPTION
Redo of https://github.com/Shopify/annex-29/pull/7 with an updated `rake`, hopefully fixes the following issue when calling `rake release`

```ruby
rake aborted!
NoMethodError: undefined method `=~' for #<Proc:0x00007f179dbd1b70 /app/data/bundler/ruby/3.2.0/gems/rake-11.3.0/lib/rake/application.rb:390 (lambda)>
/app/data/bundler/ruby/3.2.0/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/cli/exec.rb:58:in `load'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/cli/exec.rb:58:in `kernel_load'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/cli/exec.rb:23:in `run'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/cli.rb:492:in `exec'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/cli.rb:34:in `dispatch'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/cli.rb:28:in `start'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/exe/bundle:45:in `block in <top (required)>'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/app/data/bundler/ruby/3.2.0/gems/bundler-2.4.10/exe/bundle:33:in `<top (required)>'
/usr/local/ruby/bin/bundle:25:in `load'
/usr/local/ruby/bin/bundle:25:in `<main>'
```

